### PR TITLE
ENH: Remove static allocation in unbalanced tree construction

### DIFF
--- a/tree/src/data.rs
+++ b/tree/src/data.rs
@@ -1,19 +1,23 @@
 use rand::Rng;
 
-use crate::morton::{Point, PointsVec};
+use crate::morton::{Point, Points};
 
 /// Generate random distribution of PointsVec in range [0, 1),
 /// for testing.
-pub fn random(npoints: u64) -> PointsVec {
+pub fn random(npoints: u64) -> Points {
     let mut range = rand::thread_rng();
 
-    let mut points: PointsVec = Vec::new();
+    let mut points: Points = Vec::new();
 
     for _ in 0..npoints {
         let x: f64 = range.gen();
         let y: f64 = range.gen();
         let z: f64 = range.gen();
-        points.push(Point(x, y, z));
+        let mut p = Point::default();
+        p.x = x;
+        p.y = y;
+        p.z = z;
+        points.push(p);
     }
 
     points

--- a/tree/src/main.rs
+++ b/tree/src/main.rs
@@ -4,18 +4,24 @@ use mpi::traits::*;
 
 use tree::data::random;
 
-use tree::morton::Point;
+use tree::morton::{Key, Point};
 use tree::tree::unbalanced_tree;
 
 fn main() {
     // 0. Experimental Parameters
     let depth: u64 = std::env::var("DEPTH").unwrap().parse().unwrap_or(3);
     let npoints: u64 = std::env::var("NPOINTS").unwrap().parse().unwrap_or(1000);
-    let ncrit: u64 = std::env::var("NCRIT").unwrap().parse().unwrap_or(1000);
+    let ncrit: usize = std::env::var("NCRIT").unwrap().parse().unwrap_or(1000);
 
     // Generate random test points on a given process.
-    let points = random(npoints);
-    let x0 = Point(0.5, 0.5, 0.5);
+    let mut points = random(npoints);
+    let x0 = Point {
+        x: 0.5,
+        y: 0.5,
+        z: 0.5,
+        global_idx: 0,
+        key: Key::default(),
+    };
     let r0 = 0.5;
     let universe = mpi::initialize().unwrap();
 
@@ -23,11 +29,13 @@ fn main() {
     let start = Instant::now();
 
     // 1. Generate distributed unbalanced tree from a set of distributed points
-    let unbalanced = unbalanced_tree(&depth, &ncrit, universe, points, x0, r0);
+    let unbalanced = unbalanced_tree(&depth, &ncrit, universe, &mut points, x0, r0);
 
     // 2. Balance the distributed tree
 
-    // 3. Form locally essential Octree
+    // 3. Perform load balance based on interaction list density.
+
+    // 4. Form locally essential Octree
 
     // Print runtime to stdout
     println!("RUNTIME: {:?} ms", start.elapsed().as_millis());


### PR DESCRIPTION
- Remove static allocation of MAX_POINTS per leaf
- Remove load balancing based on weight of leaves per block, this will be done post 2:1 balancing now, so that it can be based on a more relevant metric - the size of the interaction lists.
- Various bug fixes.